### PR TITLE
chore(app)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
         "expo": "~54.0.35",
+        "expo-linear-gradient": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -2108,6 +2109,173 @@
         "metro-transform-worker": "0.83.3"
       }
     },
+    "node_modules/@expo/metro-config": {
+      "version": "54.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8",
+        "@expo/json-file": "~10.0.16",
+        "@expo/metro": "~54.2.0",
+        "@expo/spawn-async": "^1.7.2",
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.29.1",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "picomatch": "^4.0.3",
+        "postcss": "~8.4.32",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@expo/osascript": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
@@ -2213,6 +2381,27 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/prebuild-config": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.8",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/@expo/require-utils": {
@@ -4587,6 +4776,46 @@
         }
       }
     },
+    "node_modules/expo-asset": {
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "18.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
+      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.26",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
@@ -4708,20 +4937,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo/node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/expo/node_modules/@expo/cli": {
       "version": "54.0.25",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
@@ -4805,83 +5020,6 @@
           "optional": true
         },
         "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
-        "@react-native/normalize-colors": "0.81.5",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/json-file": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
-      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/metro-config": {
-      "version": "54.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
-      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.16",
-        "@expo/metro": "~54.2.0",
-        "@expo/spawn-async": "^1.7.2",
-        "browserslist": "^4.25.0",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "hermes-parser": "^0.29.1",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "^1.30.1",
-        "picomatch": "^4.0.3",
-        "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
           "optional": true
         }
       }
@@ -5013,35 +5151,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/expo/node_modules/expo-asset": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
-      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.13"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-constants": {
-      "version": "18.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
-      "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/expo-file-system": {
       "version": "19.0.23",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
@@ -5083,21 +5192,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/expo/node_modules/hermes-estree": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
-      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/hermes-parser": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
-      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/expo/node_modules/minimatch": {
@@ -8274,9 +8368,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",
     "expo": "~54.0.35",
+    "expo-linear-gradient": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
### Installed Expo's Linear Gradient

This will be used in the cards for OrganizationsScreen.tsx and others.

- ran: `npx expo install expo-linear-gradient`
- critical error appeared due to issues regarding build-tool dependencies inside Expo (not rly that critical to us) ran `npx audit fix` to resolve and ignore it
- ran `npx expo-doctor` to ensure no problems with expo running would occur

### _Note: This Pull is going to the Screens branch, NOT `main`._